### PR TITLE
feat: adopt TypeScript 7 native compiler for type checking

### DIFF
--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import * as TooltipPrimitive from '@radix-ui/react-tooltip'
+
+import { cn } from '@/lib/utils'
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+React.ElementRef<typeof TooltipPrimitive.Content>,
+React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      'z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      className
+    )}
+    {...props}
+  />
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@radix-ui/react-dropdown-menu": "~2.1.16",
     "@radix-ui/react-slot": "~1.3.0",
     "@radix-ui/react-toast": "~1.2.15",
+    "@radix-ui/react-tooltip": "~1.2.12",
     "cities.json": "~1.1.50",
     "class-variance-authority": "~0.7.1",
     "clsx": "~2.1.1",
@@ -50,6 +51,7 @@
     "@types/node": "~26",
     "@types/react": "~19",
     "@types/react-dom": "~19",
+    "@typescript/native-preview": "latest",
     "async-listen": "latest",
     "ava": "latest",
     "finepack": "latest",
@@ -73,7 +75,8 @@
     "postinstall": "npm run build:data",
     "prerelease": "npm run update:check && npm run contributors",
     "start": "next start",
-    "test": "ava"
+    "test": "ava",
+    "typecheck": "tsgo --noEmit"
   },
   "private": true,
   "license": "MIT",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,7 @@ import type { Config } from 'tailwindcss'
 import tailwindcssAnimate from 'tailwindcss-animate'
 
 const config: Config = {
-  darkMode: ['class'],
+  darkMode: 'class',
   content: [
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION
## What

Adopt **TypeScript 7** (the native, Go-based compiler) via `@typescript/native-preview` / `tsgo`, and add a real `typecheck` gate the repo was missing.

## Why not just bump `typescript` to 7 (#57)

The `typescript` package at 7.x is the native port. `require('typescript')` now returns only `{ version, versionMajorMinor }` — **not** the JS compiler API (`createProgram`, `parseJsonConfigFileContent`, …) that Next.js 16 and typescript-eslint (`ts-standard`) load programmatically.

So a straight bump breaks `next build`:

```
✓ Compiled successfully
Skipping validation of types
It looks like you're trying to use TypeScript but do not have the required package(s) installed.
Error: Command "npm run build" exited with 1
```

That's exactly the Vercel failure on #57. It's an ecosystem "not yet," not a repo bug — the JS API isn't in 7.0.

## How this uses TS7 instead

Next.js 16 supports the native compiler through the **`@typescript/native-preview`** package (`verify-typescript-setup.js` detects it explicitly). So:

- `typescript` stays on **6.x** (for `ts-standard` + Next config validation) — enforced by the Dependabot ignore rule added in `2cef84f`.
- `@typescript/native-preview` (TS **7.0.0-dev**, `tsgo`) is added as a devDependency.
- New script: `npm run typecheck` → `tsgo --noEmit`, the fast native compiler over the whole project.

## Latent bugs the new gate caught

`next build` runs with `typescript.ignoreBuildErrors: true`, so nothing was type-checking the app. `tsgo` surfaced two real errors, both fixed here:

| File | Error | Fix |
| --- | --- | --- |
| `components/copy-button.tsx` | imports non-existent `@/components/ui/tooltip` | added the missing shadcn `Tooltip` component + `@radix-ui/react-tooltip` |
| `tailwind.config.ts` | `darkMode: ['class']` not assignable to `DarkModeStrategy` | `darkMode: 'class'` |

## Verification

- `npm run typecheck` (tsgo / TS7) → **clean, 0 errors**
- `npm run build` (`next build`) → **green**
- `ts-standard` on changed files → **clean**

🤖 Generated with [Claude Code](https://claude.com/claude-code)